### PR TITLE
build with .net 8

### DIFF
--- a/src/Analysis/Ast/Impl/Microsoft.Python.Analysis.csproj
+++ b/src/Analysis/Ast/Impl/Microsoft.Python.Analysis.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Microsoft.Python.Analysis</RootNamespace>
     <AssemblyName>Microsoft.Python.Analysis</AssemblyName>
     <PackageId>Microsoft.Python.Analysis</PackageId>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <Authors>Apiiro</Authors>
     <Company>Apiiro</Company>
     <RepositoryUrl>https://github.com/apiiro/python-language-server</RepositoryUrl>

--- a/src/Analysis/Ast/Impl/Microsoft.Python.Analysis.csproj
+++ b/src/Analysis/Ast/Impl/Microsoft.Python.Analysis.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Microsoft.Python.Analysis</RootNamespace>
     <AssemblyName>Microsoft.Python.Analysis</AssemblyName>
     <PackageId>Microsoft.Python.Analysis</PackageId>

--- a/src/Analysis/Ast/Test/Microsoft.Python.Analysis.Tests.csproj
+++ b/src/Analysis/Ast/Test/Microsoft.Python.Analysis.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Microsoft.Python.Analysis.Tests</RootNamespace>
     <AssemblyName>Microsoft.Python.Analysis.Tests</AssemblyName>
   </PropertyGroup>
@@ -24,7 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="MicroBuild.Core" Version="0.3.0">

--- a/src/Analysis/Core/Impl/Microsoft.Python.Analysis.Core.csproj
+++ b/src/Analysis/Core/Impl/Microsoft.Python.Analysis.Core.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Microsoft.Python.Analysis</RootNamespace>
     <AssemblyName>Microsoft.Python.Analysis.Core</AssemblyName>
     <PackageId>Microsoft.Python.Analysis.Core</PackageId>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <Authors>Apiiro</Authors>
     <Company>Apiiro</Company>
     <RepositoryUrl>https://github.com/apiiro/python-language-server</RepositoryUrl>

--- a/src/Analysis/Core/Impl/Microsoft.Python.Analysis.Core.csproj
+++ b/src/Analysis/Core/Impl/Microsoft.Python.Analysis.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Microsoft.Python.Analysis</RootNamespace>
     <AssemblyName>Microsoft.Python.Analysis.Core</AssemblyName>
     <PackageId>Microsoft.Python.Analysis.Core</PackageId>

--- a/src/Core/Impl/Microsoft.Python.Core.csproj
+++ b/src/Core/Impl/Microsoft.Python.Core.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Microsoft.Python.Core</RootNamespace>
     <AssemblyName>Microsoft.Python.Core</AssemblyName>
     <PackageId>Microsoft.Python.Core</PackageId>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <Authors>Apiiro</Authors>
     <Company>Apiiro</Company>
     <RepositoryUrl>https://github.com/apiiro/python-language-server</RepositoryUrl>

--- a/src/Core/Impl/Microsoft.Python.Core.csproj
+++ b/src/Core/Impl/Microsoft.Python.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Microsoft.Python.Core</RootNamespace>
     <AssemblyName>Microsoft.Python.Core</AssemblyName>
     <PackageId>Microsoft.Python.Core</PackageId>

--- a/src/Core/Test/Microsoft.Python.Core.Tests.csproj
+++ b/src/Core/Test/Microsoft.Python.Core.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Microsoft.Python.Core.Tests</RootNamespace>
     <AssemblyName>Microsoft.Python.Core.Tests</AssemblyName>
   </PropertyGroup>
@@ -28,7 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="MicroBuild.Core" Version="0.3.0">

--- a/src/LanguageServer/Impl/Microsoft.Python.LanguageServer.csproj
+++ b/src/LanguageServer/Impl/Microsoft.Python.LanguageServer.csproj
@@ -4,7 +4,7 @@
         <RootNamespace>Microsoft.Python.LanguageServer</RootNamespace>
         <AssemblyName>Microsoft.Python.LanguageServer</AssemblyName>
         <PackageId>Microsoft.Python.LanguageServer</PackageId>
-        <Version>1.0.3</Version>
+        <Version>1.0.4</Version>
         <Authors>Apiiro</Authors>
         <Company>Apiiro</Company>
         <PackageDescription>Apiiro Python Language Server</PackageDescription>

--- a/src/LanguageServer/Impl/Microsoft.Python.LanguageServer.csproj
+++ b/src/LanguageServer/Impl/Microsoft.Python.LanguageServer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <RootNamespace>Microsoft.Python.LanguageServer</RootNamespace>
         <AssemblyName>Microsoft.Python.LanguageServer</AssemblyName>
         <PackageId>Microsoft.Python.LanguageServer</PackageId>
@@ -37,8 +37,8 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.8" />
-        <PackageReference Include="NewtonSoft.Json" Version="12.0.3" />
-        <PackageReference Include="StreamJsonRpc" Version="2.5.46" />
+        <PackageReference Include="NewtonSoft.Json" Version="13.0.3" />
+        <PackageReference Include="StreamJsonRpc" Version="2.18.48" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\..\Analysis\Ast\Impl\Microsoft.Python.Analysis.csproj" />

--- a/src/LanguageServer/Test/Microsoft.Python.LanguageServer.Tests.csproj
+++ b/src/LanguageServer/Test/Microsoft.Python.LanguageServer.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Microsoft.Python.LanguageServer.Tests</RootNamespace>
     <AssemblyName>Microsoft.Python.LanguageServer.Tests</AssemblyName>
   </PropertyGroup>
@@ -24,14 +24,16 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="MicroBuild.Core" Version="0.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="NewtonSoft.Json" Version="13.0.3" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="StreamJsonRpc" Version="2.18.48" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Analysis\Ast\Impl\Microsoft.Python.Analysis.csproj" />

--- a/src/Parsing/Impl/Microsoft.Python.Parsing.csproj
+++ b/src/Parsing/Impl/Microsoft.Python.Parsing.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Microsoft.Python.Parsing</RootNamespace>
     <AssemblyName>Microsoft.Python.Parsing</AssemblyName>
     <PackageId>Microsoft.Python.Parsing</PackageId>

--- a/src/Parsing/Impl/Microsoft.Python.Parsing.csproj
+++ b/src/Parsing/Impl/Microsoft.Python.Parsing.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Microsoft.Python.Parsing</RootNamespace>
     <AssemblyName>Microsoft.Python.Parsing</AssemblyName>
     <PackageId>Microsoft.Python.Parsing</PackageId>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <Authors>Apiiro</Authors>
     <Company>Apiiro</Company>
     <RepositoryUrl>https://github.com/apiiro/python-language-server</RepositoryUrl>

--- a/src/Parsing/Test/Microsoft.Python.Parsing.Tests.csproj
+++ b/src/Parsing/Test/Microsoft.Python.Parsing.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Microsoft.Python.Parsing.Tests</RootNamespace>
     <AssemblyName>Microsoft.Python.Parsing.Tests</AssemblyName>
   </PropertyGroup>
@@ -28,7 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="MicroBuild.Core" Version="0.3.0">

--- a/src/UnitTests/Core/Impl/UnitTests.Core.csproj
+++ b/src/UnitTests/Core/Impl/UnitTests.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Microsoft.Python.UnitTests.Core</RootNamespace>
     <AssemblyName>Microsoft.Python.UnitTests.Core</AssemblyName>
   </PropertyGroup>


### PR DESCRIPTION
The language server did fails to run since we updated the containers to .net 8
This version should fix it.